### PR TITLE
Add ViewIGStory to Competitor Analysis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -392,6 +392,7 @@ This list provided by **[Marketing Tools List](https://marketingtoolslist.com)**
   - [Crayon](https://www.crayon.co) - Review - Competitive intelligence platform that tracks your competitors' digital footprints to uncover strategic insights.
   - [Owler](https://www.owler.com) - Review - Business insights platform that provides real-time news, alerts, and analysis on competitors and industry trends.
   - [Kompyte](https://www.kompyte.com) - Review - Competitor tracking software that monitors competitor websites, social media, and online ads in real-time.
+  - [ViewIGStory](https://www.view-ig-story.com) - Review - Anonymous Instagram story viewer for competitor research; observe how competing brands tell stories without leaving a trace in their viewer list.
 
 
 ## Brand Management


### PR DESCRIPTION
Adds **ViewIGStory** (https://www.view-ig-story.com) to the **Market Research and Competitor Analysis → Competitor Analysis** subsection.

Anonymous Instagram story viewer for competitor research — observe how competing brands tell stories on Instagram (cadence, format, CTAs, promotional patterns) without leaving a trace in their viewer list.

Complements the existing competitor-analysis entries (SpyFu, SimilarWeb, Crayon, Owler, Kompyte) by covering the social-side specifically. SimilarWeb/Crayon already track web/social analytics but neither shows individual story content.

Single-line entry matching the existing format. Inserted after Kompyte.

Disclosure: I'm the maintainer of ViewIGStory.