### PR TITLE
Add Riffkit to Content Creation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,7 @@ This list provided by **[Marketing Tools List](https://marketingtoolslist.com)**
   - [Piktochart](https://piktochart.com) - Review - Infographic maker and presentation tool to create visually appealing content.
   - [Adobe Spark](https://spark.adobe.com) - Review - Suite of design apps for creating social graphics, web pages, and videos.
   - [Tellers.AI](https://tellers.ai) - Review - Turn your scripts, articles and podcasts into videos based on your own footage.
+  - [Riffkit](https://riffkit.ai) - Review - Riffs a winning TikTok's emotion formula into a new short video with your product, character, and language (EN/ES); also makes UGC ad creative for TikTok/Meta.
 
 ### Content Management Systems (CMS)
 


### PR DESCRIPTION
Adds **Riffkit** under Content Creation (alongside the video tools like Animoto / Tellers.AI).

Riffkit riffs a winning TikTok's emotion formula into a brand-new short video with your product, character, and language (English/Spanish), and also makes UGC-style ad creative for TikTok/Meta. Hosted service; the source clip is never re-uploaded, so the output is your own original. https://riffkit.ai
